### PR TITLE
switch event listener to keyup to allow repositioning of the caret

### DIFF
--- a/Quick Tab/js/search.js
+++ b/Quick Tab/js/search.js
@@ -52,27 +52,12 @@ Search.prototype.query = function(term, tabArray)
     }
 };
 
-Search.prototype.searchInputKeydown = function(e, tabArray)
+Search.prototype.searchInputKeyup = function(e, tabArray)
 {
     if(!this.isValidSearchChar(e, 0))
         return;
 
-    var term;
-
-    if (e.keyCode == 13) {
-        // enter
-        var el = $$('.tab').find(function(el) { return el.visible(); });
-        var tabId = parseInt(el.id.replace('tab-', ''));
-        if (tabId) {
-            chrome.tabs.update(tabId, {selected: true});
-            window.close();
-        }
-        return;
-    } else if (e.keyCode == 8) {
-        term = this.searchInputReference.value.substring(0, this.searchInputReference.value.length - 1);
-    }
-    else
-        term = this.searchInputReference.value.concat(String.fromCharCode(e.keyCode));
+    var term = this.searchInputReference.value;
 
     if(term.length != 0)
     {

--- a/Quick Tab/js/view.js
+++ b/Quick Tab/js/view.js
@@ -9,12 +9,22 @@ function Manager()
 
     this.help.show();
 
-    //User pressed a key in the search box
+    // Block up and down arrows in search box to prevent repositioning of carret to beginning/end
     this.search.searchInputReference.addEventListener('keydown', function(e) {
-        if(!this.search.isValidSearchChar(e)) {
+        keyCode = e.keyCode;
+
+        if(
+            keyCode == 38 ||					   //Up
+            keyCode == 40   					   //Down
+        ){
             e.preventDefault();
-        } else {
-            this.search.searchInputKeydown(e, this.tabArray);
+        }
+    }.bind(this));
+    
+    //User pressed a key in the search box
+    this.search.searchInputReference.addEventListener('keyup', function(e) {
+        if(this.search.isValidSearchChar(e)) {
+            this.search.searchInputKeyup(e, this.tabArray);
         }
     }.bind(this));
 


### PR DESCRIPTION
Hi again,
I switched the event listener to **keyup** to be able to move the caret within the search term and correct typos without the need to delete the end of the term up to the typo.
Also switching to **keyup** makes the method shorter as there is no need to concat the new char to the term or delete the last char if backspace was pressed. Now only reading the edit field is needed.
Also jumping to the tab by pressing **enter** still works.
Only navigating up and down through the tab list by arrow keys affected the caret position like **home** and **end** keys do. Hence I used **keydown** event listener to block the keys in the edit field. In the tab list it still works as intended.