### PR TITLE
allow searching for parts of words

### DIFF
--- a/Quick Tab/js/search.js
+++ b/Quick Tab/js/search.js
@@ -29,6 +29,10 @@ Search.prototype.clear = function(tabArray)
 
 Search.prototype.query = function(term, tabArray)
 {
+    //Remove unneeded spaces
+    term = term.replace(/  +/g, " ");
+    //allow searching for parts of expressions. Space is delimiter.
+    term = term.split(" ").join(".*?");
     //The term that must be matched
     var regex = new RegExp('(' + term + ')', 'gi');
     var tabCounter = 0;

--- a/Quick Tab/js/tab.js
+++ b/Quick Tab/js/tab.js
@@ -76,7 +76,12 @@ Tab.prototype.visible = function(visible)
 
 Tab.prototype.close = function()
 {
-    //todo: remove from tabArray
+	var array = this.manager.tabArray;
+	var index = array.indexOf(this);
+	if(index > -1){
+		array.splice(index, 1);
+	}
+	
     this.view.parentNode.removeChild(this.view);
     chrome.tabs.remove(this.id);
 };


### PR DESCRIPTION
this one allows to type only parts of words which don't need to be adjacent to find a tab.
Taken your introduction picture, it is sufficient to write something like "pan dis" to find "Panic at the disco". Currently you have to match the exact name.
![image](https://cloud.githubusercontent.com/assets/5376779/21745680/128b5366-d531-11e6-8669-75e403044d51.png)

Also there was some todo, which I implemented.